### PR TITLE
[BUGFIX] Infinit loop in the CSV output

### DIFF
--- a/src/bin/mft_dump.rs
+++ b/src/bin/mft_dump.rs
@@ -19,6 +19,7 @@ use std::fmt::Write as FmtWrite;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 use std::{fs, io, path};
+use std::collections::HashSet;
 
 #[derive(Debug, PartialOrd, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
@@ -297,6 +298,8 @@ impl MftDump {
             None => Box::new(0..number_of_entries as usize) as Box<dyn Iterator<Item = usize>>,
         };
 
+        let mut visited_entries = HashSet::new();
+
         for i in entries {
             let entry = parser.get_entry(i as u64);
 
@@ -312,7 +315,7 @@ impl MftDump {
             };
 
             if let Some(data_streams_dir) = &self.data_streams_output {
-                if let Ok(Some(path)) = parser.get_full_path_for_entry(&entry) {
+                if let Ok(Some(path)) = parser.get_full_path_for_entry(&entry, &mut visited_entries) {
                     let sanitized_path = sanitized(&path.to_string_lossy());
 
                     for (i, (name, stream)) in entry

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use chrono::{DateTime, Utc};
 use std::io::{Read, Seek};
 use std::path::PathBuf;
+use std::collections::HashSet;
 
 /// Used for CSV output
 #[derive(Serialize)]
@@ -95,6 +96,8 @@ impl FlatMftEntryWithName {
             .iter()
             .any(|a| a.header.type_code == MftAttributeType::DATA && !a.header.name.is_empty());
 
+        let mut visited_entries = HashSet::new();
+
         FlatMftEntryWithName {
             entry_id: entry.header.record_number,
             signature: String::from_utf8(entry.header.signature.to_ascii_uppercase())
@@ -119,7 +122,7 @@ impl FlatMftEntryWithName {
             file_name_created: file_name.as_ref().map(|i| i.created),
             file_size,
             full_path: parser
-                .get_full_path_for_entry(entry)
+                .get_full_path_for_entry(entry, &mut visited_entries)
                 .expect("I/O Err")
                 .unwrap_or_default(),
         }


### PR DESCRIPTION
### Description:
Fixes an infinite loop and stack overflow error in CSV format output.

### Details:
During the CSV format output, when the entry ID is the same as the entry ID of the grandparent, it causes an infinite loop that results in a stack overflow. This leads to the following error message:

```
Thread 'main' has overflowed its stack
Fatal runtime error: stack overflow
Aborted (core dumped)
```

### Proposed Solution:
To fix this bug, I suggest utilizing a HashSet to store the entity IDs that have already been visited for a given entry. This will prevent the infinite loop.