### PR TITLE
Use consistent path separator on all OSes

### DIFF
--- a/src/bin/mft_dump.rs
+++ b/src/bin/mft_dump.rs
@@ -313,7 +313,7 @@ impl MftDump {
 
             if let Some(data_streams_dir) = &self.data_streams_output {
                 if let Ok(Some(path)) = parser.get_full_path_for_entry(&entry) {
-                    let sanitized_path = sanitized(&path.to_string_lossy());
+                    let sanitized_path = sanitized(&path.to_string());
 
                     for (i, (name, stream)) in entry
                         .iter_attributes()

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -8,7 +8,6 @@ use serde::Serialize;
 
 use chrono::{DateTime, Utc};
 use std::io::{Read, Seek};
-use std::path::PathBuf;
 
 /// Used for CSV output
 #[derive(Serialize)]
@@ -52,7 +51,7 @@ pub struct FlatMftEntryWithName {
     pub file_name_last_access: Option<DateTime<Utc>>,
     pub file_name_created: Option<DateTime<Utc>>,
 
-    pub full_path: PathBuf,
+    pub full_path: String,
 }
 
 impl FlatMftEntryWithName {


### PR DESCRIPTION
The OS where an MFT is parsed shouldn't affect the parsed output.

Convert all paths from PathBuf to String. We're not using any PathBuf methods except join, and can use string formatting instead, so MFT paths don't differ from OS to OS.