### PR TITLE
Bump most Dependencies to Latest and Fix Benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,19 +18,18 @@ bitflags = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 csv = "1"
-thiserror = "1"
+thiserror = "2.0"
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 winstructs = "0.3.0"
-lru = "0.9.0"
-itertools = "0.10"
+lru = "0.12.0"
 rand = "0.8"
 
 # `mft_dump` dependencies
 clap = { version = "4", optional = true }
 anyhow = { version = "1.0", optional = true }
 simplelog = { version = "0.12", optional = true }
-dialoguer = { version = "0.10", optional = true }
+dialoguer = { version = "0.11", optional = true }
 indoc = { version = "2.0", optional = true }
 
 [features]
@@ -43,16 +42,16 @@ default-features = false
 features = ["clock", "serde", "std"]
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 skeptic = "0.13"
 assert_cmd = "2.0"
-predicates = "2.1"
-env_logger = "0.10"
+predicates = "3.1"
+env_logger = "0.11"
 tempfile = "3.2"
 
 # rexpect relies on unix process semantics, but it's only used for process interaction tests.
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-rexpect = "0.5"
+rexpect = "0.6"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/src/benches/benchmark.rs
+++ b/src/benches/benchmark.rs
@@ -3,7 +3,8 @@ extern crate criterion;
 extern crate mft;
 
 use criterion::Criterion;
-use mft::{MftEntry, MftParser, ReadSeek};
+use mft::{MftEntry, MftParser};
+use std::io::{Read, Seek};
 
 fn process_1000_mft_records(sample: &[u8]) {
     let mut parser = MftParser::from_buffer(sample.to_vec()).unwrap();
@@ -16,7 +17,7 @@ fn process_1000_mft_records(sample: &[u8]) {
     }
 }
 
-fn get_full_path(parser: &mut MftParser<impl ReadSeek>, entries: &[MftEntry]) {
+fn get_full_path(parser: &mut MftParser<impl Read+Seek>, entries: &[MftEntry]) {
     for entry in entries {
         parser.get_full_path_for_entry(&entry).unwrap();
     }


### PR DESCRIPTION
I don't know if this project is still actively accepting pull requests but I will upload the fixes I have been putting in for Chainsaw here as well. This pull request updates the dependencies to the latest versions, removes itertools as it does not appear to be used anywhere and fixes the cargo bench benchmark file to run after changes to the use of read seek. 

This does not bump bitflags as that requires more changes which will be a separate pull request.