### PR TITLE
Attempt to Update Bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 log = { version = "0.4", features = ["release_max_level_debug"] }
 encoding = "0.2"
 byteorder = "1"
-bitflags = "1"
+bitflags = "2.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 csv = "1"

--- a/src/attribute/mod.rs
+++ b/src/attribute/mod.rs
@@ -13,6 +13,7 @@ use crate::err::Result;
 use crate::impl_serialize_for_bitflags;
 
 use std::io::{Cursor, Read, Seek};
+use std::fmt;
 
 use bitflags::bitflags;
 
@@ -211,6 +212,7 @@ bitflags! {
     /// <https://github.com/EricZimmerman/MFT/blob/3bed2626ee85e9a96a6db70a17407d0c3696056a/MFT/Attributes/StandardInfo.cs#L10>
     /// <https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9>
     ///
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct FileAttributeFlags: u32 {
         const FILE_ATTRIBUTE_READONLY             = 0x0000_0001;
         const FILE_ATTRIBUTE_HIDDEN               = 0x0000_0002;
@@ -234,15 +236,80 @@ bitflags! {
     }
 }
 
+impl fmt::Display for FileAttributeFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for flag in [
+            FileAttributeFlags::FILE_ATTRIBUTE_READONLY,
+            FileAttributeFlags::FILE_ATTRIBUTE_HIDDEN,
+            FileAttributeFlags::FILE_ATTRIBUTE_SYSTEM,
+            FileAttributeFlags::FILE_ATTRIBUTE_DIRECTORY,
+            FileAttributeFlags::FILE_ATTRIBUTE_ARCHIVE,
+            FileAttributeFlags::FILE_ATTRIBUTE_DEVICE,
+            FileAttributeFlags::FILE_ATTRIBUTE_NORMAL,
+            FileAttributeFlags::FILE_ATTRIBUTE_TEMPORARY,
+            FileAttributeFlags::FILE_ATTRIBUTE_SPARSE_FILE,
+            FileAttributeFlags::FILE_ATTRIBUTE_REPARSE_POINT,
+            FileAttributeFlags::FILE_ATTRIBUTE_COMPRESSED,
+            FileAttributeFlags::FILE_ATTRIBUTE_OFFLINE,
+            FileAttributeFlags::FILE_ATTRIBUTE_NOT_CONTENT_INDEXED,
+            FileAttributeFlags::FILE_ATTRIBUTE_ENCRYPTED,
+            FileAttributeFlags::FILE_ATTRIBUTE_INTEGRITY_STREAM,
+            FileAttributeFlags::FILE_ATTRIBUTE_NO_SCRUB_DATA,
+            FileAttributeFlags::FILE_ATTRIBUTE_HAS_EA,
+            FileAttributeFlags::FILE_ATTRIBUTE_IS_DIRECTORY,
+            FileAttributeFlags::FILE_ATTRIBUTE_INDEX_VIEW,
+            // Add other flags as needed
+        ] {
+            if self.contains(flag) {
+                if !first {
+                    write!(f, " | ")?;
+                }
+                let flag_str = format!("{:?}", flag);
+                let flag_str = flag_str.strip_prefix("FileAttributeFlags(").unwrap_or(&flag_str);
+                let flag_str = flag_str.strip_suffix(")").unwrap_or(&flag_str);
+                write!(f, "{}", flag_str)?;
+                first = false;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl_serialize_for_bitflags! {FileAttributeFlags}
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct AttributeDataFlags: u16 {
         const IS_COMPRESSED     = 0x0001;
         const COMPRESSION_MASK  = 0x00FF;
         const ENCRYPTED         = 0x4000;
         const SPARSE            = 0x8000;
+    }
+}
+
+impl fmt::Display for AttributeDataFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for flag in [
+            AttributeDataFlags::IS_COMPRESSED,
+            AttributeDataFlags::COMPRESSION_MASK,
+            AttributeDataFlags::ENCRYPTED,
+            AttributeDataFlags::SPARSE,
+            // Add other flags as needed
+        ] {
+            if self.contains(flag) {
+                if !first {
+                    write!(f, " | ")?;
+                }
+                let flag_str = format!("{:?}", flag);
+                let flag_str = flag_str.strip_prefix("AttributeDataFlags(").unwrap_or(&flag_str);
+                let flag_str = flag_str.strip_suffix(")").unwrap_or(&flag_str);
+                write!(f, "{}", flag_str)?;
+                first = false;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/attribute/x90.rs
+++ b/src/attribute/x90.rs
@@ -10,6 +10,7 @@ use bitflags::bitflags;
 use serde::Serialize;
 use winstructs::ntfs::mft_reference::MftReference;
 use std::io::SeekFrom;
+use std::fmt;
 use num_derive::FromPrimitive;    
 use num_traits::FromPrimitive;
 
@@ -51,11 +52,41 @@ pub enum IndexCollationRules {
 }
 
 bitflags! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct IndexRootFlags: u32 {
         const SMALL_INDEX = 0x00;
         const LARGE_INDEX = 0x01;
     }
 }
+
+impl fmt::Display for IndexRootFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for flag in [
+            IndexRootFlags::SMALL_INDEX,
+            IndexRootFlags::LARGE_INDEX,
+            // Add other flags as needed
+        ] {
+            if self.contains(flag) {
+                if !first {
+                    write!(f, " | ")?;
+                }
+                let flag_str = if flag.bits() == 0x00 {
+                    "SMALL_INDEX".to_string()
+                } else {
+                let flag_str = format!("{:?}", flag);
+                let flag_str = flag_str.strip_prefix("IndexRootFlags(").unwrap_or(&flag_str);
+                let flag_str = flag_str.strip_suffix(")").unwrap_or(&flag_str);
+                flag_str.to_string()
+            };
+                write!(f, "{}", flag_str)?;
+                first = false;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl_serialize_for_bitflags! {IndexRootFlags}
 
 impl IndexRootAttr {
@@ -102,11 +133,36 @@ pub struct IndexEntryHeader {
     pub fname_info: FileNameAttr
 }
 bitflags! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct IndexEntryFlags: u32 {
         const INDEX_ENTRY_NODE = 0x01;
         const INDEX_ENTRY_END  = 0x02;
     }
 }
+
+impl fmt::Display for IndexEntryFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for flag in [
+            IndexEntryFlags::INDEX_ENTRY_NODE,
+            IndexEntryFlags::INDEX_ENTRY_END,
+            // Add other flags as needed
+        ] {
+            if self.contains(flag) {
+                if !first {
+                    write!(f, " | ")?;
+                }
+                let flag_str = format!("{:?}", flag);
+                let flag_str = flag_str.strip_prefix("IndexEntryFlags(").unwrap_or(&flag_str);
+                let flag_str = flag_str.strip_suffix(")").unwrap_or(&flag_str);
+                write!(f, "{}", flag_str)?;
+                first = false;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl_serialize_for_bitflags! {IndexEntryFlags}
 
 impl IndexEntryHeader {  

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,7 +6,7 @@ macro_rules! impl_serialize_for_bitflags {
             where
                 S: serde::ser::Serializer,
             {
-                serializer.serialize_str(&format!("{:?}", &self))
+                serializer.serialize_str(&self.to_string())
             }
         }
     };


### PR DESCRIPTION
This bumps bitflags up to the latest release 2.7. In order to do this I had to add derive lines to maintain compatibility with the older version. I also had to use fmt::Display to change the output back to the way it was before  the update as the latest version of bitflags outputs like this FileAttributeFlags(FILE_ATTRIBUTE_READONLY) rather than FILE_ATTRIBUTE_READONLY. 

One potential issue I noticed is when I used mft_dump json with mft_dump --output-format json --output test1.json mft.bin
and compared the outputs of the older version is that it outputs IndexRootFlags with both SMALL_INDEX and LARGE_INDEX rather than just LARGE_INDEX for the older version. This might be due to the way the bits are handled now but the rest of the outputs seem to match fine and pass the tests.