### PR TITLE
Don't force release_max_level_debug feature on log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [dependencies]
-log = { version = "0.4", features = ["release_max_level_debug"] }
+log = "0.4"
 byteorder = "1"
 bitflags = "2"
 serde = { version = "1", features = ["derive"] }
@@ -49,7 +49,7 @@ utf16-simd = "0.1.0"
 
 [features]
 default = ["mft_dump"]
-mft_dump = ["anyhow", "simplelog", "dialoguer", "indoc", "clap", "sonic-rs"]
+mft_dump = ["anyhow", "simplelog", "dialoguer", "indoc", "clap", "sonic-rs", "log/release_max_level_debug"]
 
 [dev-dependencies]
 criterion = "0.7"


### PR DESCRIPTION
This crate enables the "release_max_level_debug" feature of the `log` crate which has a global affect on all programs that include this project as a library. This PR makes it so that the feature is only enabled when building the binary.